### PR TITLE
Changing the public API to be stable in the future

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2020 tarent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ partitions, as this is a sane default for our platform.
 In code you can use it like this:
 
 ```
-err := kafkaadmin.EnsureTopicExists(ctx, kafkaURL, tlsConfig, topicName)
+err := kafkaadmin.EnsureCompactedTopicExists(ctx, kafkaURL, tlsConfig, topicName)
 if err != nil {
 	return fmt.Errorf("ensuring topic %q failed: %w", topicName, err)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/tarent/kafkaadmin
 
-go 1.13
+go 1.15
 
 require (
 	github.com/confluentinc/confluent-kafka-go v1.4.2
 	github.com/fvosberg/errtypes v0.0.0-20190318091206-e95b29c1c67c
+	github.com/golang/snappy v0.0.2 // indirect
 	github.com/segmentio/kafka-go v0.4.2
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/fvosberg/errtypes v0.0.0-20190318091206-e95b29c1c67c
 	github.com/golang/snappy v0.0.2 // indirect
 	github.com/segmentio/kafka-go v0.4.2
-	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.6.1
 	github.com/tmstff/kafka-testing-go v0.1.5
 )

--- a/go.sum
+++ b/go.sum
@@ -93,7 +93,6 @@ github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59P
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.2 h1:aeE13tS0IiQgFjYdoL8qN3K1N2bXXtI6Vi51/y7BpMw=
+github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -91,6 +93,7 @@ github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59P
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/topics.go
+++ b/topics.go
@@ -19,9 +19,15 @@ func EnsureCompactedTopicExists(ctx context.Context, kafkaURL string, tlsConfig 
 }
 
 func EnsureTopicExistsWithConfig(ctx context.Context, kafkaURL string, tlsConfig *tls.Config, topicConfig kafka.TopicConfig) error {
+	errs := make(chan error, 1)
 	for {
+		go func() {
+			err := ensureTopicExistsWithConfig(kafkaURL, tlsConfig, topicConfig)
+			errs <- err
+		}()
+
 		select {
-		case err := ensureTopicExistsWithConfig(kafkaURL, tlsConfig, topicConfig):
+		case err := <-errs:
 			if err == nil {
 				return err
 			}

--- a/topics_test.go
+++ b/topics_test.go
@@ -2,14 +2,15 @@ package kafkaadmin
 
 import (
 	"context"
-	"github.com/confluentinc/confluent-kafka-go/kafka"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
-	"github.com/tmstff/kafka-testing-go"
 	"math/rand"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	kafkatesting "github.com/tmstff/kafka-testing-go"
 )
 
 func TestTopicCreation(t *testing.T) {
@@ -26,7 +27,7 @@ func TestTopicCreation(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	topic := strconv.FormatUint(rand.Uint64(), 10)
 
-	config := DefaultConfig(topic)
+	config := CompactedTopicConfig(topic)
 	config.ReplicationFactor = 1
 
 	err = EnsureTopicExistsWithConfig(ctx, kafkaUrl, nil, config)

--- a/topics_test.go
+++ b/topics_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	kafkatesting "github.com/tmstff/kafka-testing-go"
 )
@@ -49,9 +48,9 @@ func TestTopicCreation(t *testing.T) {
 	assert.NotNil(t, configResources)
 
 	for _, cr := range configResources {
-		logrus.Infof("config resource %s", cr)
+		t.Logf("config resource %s", cr)
 		for _, c := range cr.Config {
-			logrus.Infof("config %s", c)
+			t.Logf("config %s", c)
 		}
 	}
 


### PR DESCRIPTION
To have a stable API I've thought about changing the name of the public function to contain Compacted.

Minor changes in this PR

- Adding a license
- Updating go to 1.15
- supporting "direct" cancellation via the context
- removing a hard timeout in this module
- removing logrus as a dependency

What do you think?