### PR TITLE
feat: add policy delete

### DIFF
--- a/topics.go
+++ b/topics.go
@@ -61,6 +61,10 @@ func TopicConfigCleanupPolicyDelete(topicName string) kafka.TopicConfig {
 				ConfigName:  "cleanup.policy",
 				ConfigValue: "delete",
 			},
+			{
+				ConfigName:  "retention.ms",
+				ConfigValue: "1209600000",
+			},
 		},
 	}
 }


### PR DESCRIPTION
I've added a function to create a topic with the cleanup policy delete.

We should add the functionality to check if the configuration of a pre existing topic is correct in the future.